### PR TITLE
enhanced BTCInfo thread to use more available API sources

### DIFF
--- a/nmcontroller.py
+++ b/nmcontroller.py
@@ -90,7 +90,8 @@ def web_monitor():
         latest_version=latest_version,
         reward_value=btcinfo_thread.block_reward_value,
         block_reward=btcinfo_thread.block_reward,
-        btc_price=btcinfo_thread.btc_price
+        btc_price=btcinfo_thread.btc_price,
+        btc_price_source=btcinfo_thread.btc_price_source,
     )
 
 

--- a/templates/web_monitor.html
+++ b/templates/web_monitor.html
@@ -221,7 +221,7 @@
     </div>
 
     <div style="text-align: center; margin-top: 20px;">
-        <h4 style="color: #FFD700;">BTC/USD: ${{ "{:,}".format(btc_price) }}<br> Block Reward: {{ block_reward }} BTC
+        <h4 style="color: #FFD700;">{{ btc_price_source }} BTC/USD: ${{ "{:,}".format(btc_price) }}<br> Block Reward: {{ block_reward }} BTC
             (${{ "{:,}".format(reward_value) }})</h4>
     </div>
 </div>

--- a/threads/btcinfo_thread.py
+++ b/threads/btcinfo_thread.py
@@ -67,7 +67,6 @@ class BtcInfoThread(ManagedThread):
             logging.error(f"[BtcInfoThread] Unexpected error: {e}", exc_info=True)
 
             # We want to continue on so without this info so zero out what we have
-            self.btc_price = 0.0
             self.block_reward = 0.0
             self.block_reward_value = 0.00
 

--- a/threads/btcinfo_thread.py
+++ b/threads/btcinfo_thread.py
@@ -56,19 +56,19 @@ class BtcInfoThread(ManagedThread):
             # Calculate block reward value in USD
             self.block_reward_value = round(self.block_reward * self.btc_price, 2)
 
-            logging.info(f"[BtcInfoThread] BTC Price: ${self.btc_price}, Block Reward: {self.block_reward} BTC, Reward Value: ${self.block_reward_value}")
-
         except requests.RequestException as e:
-            logging.error(f"[BtcInfoThread] Error fetching data: {e}", exc_info=True)
+            logging.error(f"[BtcInfoThread] Error fetching data from blockchain.info: {e}", exc_info=True)
         except ValueError as e:
-            logging.error(f"[BtcInfoThread] Unexpected data format: {e}", exc_info=True)
+            logging.error(f"[BtcInfoThread] Unexpected data format from blockchain.info: {e}", exc_info=True)
         except Exception as e:
             # Generic exception catch for anything that isn't already caught
-            logging.error(f"[BtcInfoThread] Unexpected error: {e}", exc_info=True)
+            logging.error(f"[BtcInfoThread] Unexpected error from blockchain.info: {e}", exc_info=True)
 
             # We want to continue on so without this info so zero out what we have
             self.block_reward = 0.0
             self.block_reward_value = 0.00
+
+        logging.info(f"[BtcInfoThread] BTC Price: ${self.btc_price}, Block Reward: {self.block_reward} BTC, Reward Value: ${self.block_reward_value}")
 
     @staticmethod
     def get_btc_price():

--- a/threads/btcinfo_thread.py
+++ b/threads/btcinfo_thread.py
@@ -7,7 +7,6 @@ from threads.managed_thread import ManagedThread
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
-BTC_PRICE_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'
 LATEST_BLOCK_HEIGHT_URL = "https://blockchain.info/q/getblockcount"
 
 
@@ -24,6 +23,7 @@ class BtcInfoThread(ManagedThread):
         :param update_seconds: Interval for fetching data (default: 30 minutes).
         """
         super().__init__(name=name, update_seconds=update_seconds)
+        self.btc_price_source = ''
         self.btc_price = 0.0
         self.block_reward = 0.0
         self.block_reward_value = 0.00
@@ -40,16 +40,8 @@ class BtcInfoThread(ManagedThread):
     def get_btc_block_reward_value(self):
         """Fetches the Bitcoin price and calculates the block reward value in USD."""
         try:
-            # Fetch BTC price in USD
-            btc_price_response = requests.get(BTC_PRICE_URL, timeout=10)
-            btc_price_response.raise_for_status()
-            btc_price_data = btc_price_response.json()
-
-            if "bitcoin" in btc_price_data and "usd" in btc_price_data["bitcoin"]:
-                self.btc_price = round(btc_price_data["bitcoin"]["usd"], 2)
-            else:
-                logging.warning("[BtcInfoThread] Unexpected BTC price response format.")
-                return
+            # Get Bitcoin price
+            self.btc_price_source, self.btc_price = self.get_btc_price()
 
             # Get the latest Bitcoin block height
             block_height_response = requests.get(LATEST_BLOCK_HEIGHT_URL, timeout=10)
@@ -70,6 +62,51 @@ class BtcInfoThread(ManagedThread):
             logging.error(f"[BtcInfoThread] Error fetching data: {e}", exc_info=True)
         except ValueError as e:
             logging.error(f"[BtcInfoThread] Unexpected data format: {e}", exc_info=True)
+        except Exception as e:
+            # Generic exception catch for anything that isn't already caught
+            logging.error(f"[BtcInfoThread] Unexpected error: {e}", exc_info=True)
+
+            # We want to continue on so without this info so zero out what we have
+            self.btc_price = 0.0
+            self.block_reward = 0.0
+            self.block_reward_value = 0.00
+
+    @staticmethod
+    def get_btc_price():
+        """Fetch BTC price in USD from multiple free crypto APIs."""
+        API_SOURCES = [
+            {
+                "name": "Coingecko",
+                "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+                "parser": lambda price_data: round(data["bitcoin"]["usd"], 2)
+            },
+            {
+                "name": "Kraken",
+                "url": "https://api.kraken.com/0/public/Ticker?pair=XBTUSD",
+                "parser": lambda price_data: round(float(data["result"]["XXBTZUSD"]["c"][0]), 2)
+            },
+            {
+                "name": "OKX",
+                "url": "https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT",
+                "parser": lambda price_data: round(float(data["data"][0]["last"]), 2)
+            }
+        ]
+
+        # Try one of the free crypto APIs to get the Bitcoin price
+        for source in API_SOURCES:
+            try:
+                response = requests.get(source["url"], timeout=10)
+                response.raise_for_status()
+                data = response.json()
+                return source['name'], source["parser"](data)
+            except (requests.RequestException, KeyError, IndexError, ValueError) as e:
+                logging.warning(f"[BtcInfoThread] {source['name']} API failed: {e}")
+            except Exception as e:
+                # Catch anything else that falls through
+                logging.error(f"[BtcInfoThread] {source['name']} API failed: {e}")
+
+        # Return 0.0 if all APIs fail
+        return '', 0.0
 
     def sleep_for(self, seconds):
         """Utility method to sleep without blocking thread stopping."""

--- a/threads/btcinfo_thread.py
+++ b/threads/btcinfo_thread.py
@@ -12,37 +12,37 @@ BTC_PRICE_API_SOURCES = [
     {
         "name": "Coingecko",
         "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
-        "parser": lambda price_data: round(data["bitcoin"]["usd"], 2)
+        "parser": lambda price_data: round(price_data["bitcoin"]["usd"], 2)
     },
     {
         "name": "Kraken",
         "url": "https://api.kraken.com/0/public/Ticker?pair=XBTUSD",
-        "parser": lambda price_data: round(float(data["result"]["XXBTZUSD"]["c"][0]), 2)
+        "parser": lambda price_data: round(float(price_data["result"]["XXBTZUSD"]["c"][0]), 2)
     },
     {
         "name": "OKX",
         "url": "https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT",
-        "parser": lambda price_data: round(float(data["data"][0]["last"]), 2)
+        "parser": lambda price_data: round(float(price_data["data"][0]["last"]), 2)
     },
     {
         "name": "Bitstamp",
         "url": "https://www.bitstamp.net/api/v2/ticker/btcusd/",
-        "parser": lambda price_data: round(float(data["last"]), 2)
+        "parser": lambda price_data: round(float(price_data["last"]), 2)
     },
     {
         "name": "Huobi",
         "url": "https://api.huobi.pro/market/detail/merged?symbol=btcusdt",
-        "parser": lambda price_data: round(float(data["tick"]["close"]), 2)
+        "parser": lambda price_data: round(float(price_data["tick"]["close"]), 2)
     },
     {
         "name": "ByBit",
         "url": "https://api.bybit.com/v2/public/tickers?symbol=BTCUSD",
-        "parser": lambda price_data: round(float(data["result"][0]["last_price"]), 2)
+        "parser": lambda price_data: round(float(price_data["result"][0]["last_price"]), 2)
     },
     {
         "name": "MEXC",
         "url": "https://api.mexc.com/api/v3/ticker/price?symbol=BTCUSDT",
-        "parser": lambda price_data: round(float(data["price"]), 2)
+        "parser": lambda price_data: round(float(price_data["price"]), 2)
     },
 ]
 

--- a/threads/btcinfo_thread.py
+++ b/threads/btcinfo_thread.py
@@ -8,6 +8,43 @@ from threads.managed_thread import ManagedThread
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
 LATEST_BLOCK_HEIGHT_URL = "https://blockchain.info/q/getblockcount"
+BTC_PRICE_API_SOURCES = [
+    {
+        "name": "Coingecko",
+        "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+        "parser": lambda price_data: round(data["bitcoin"]["usd"], 2)
+    },
+    {
+        "name": "Kraken",
+        "url": "https://api.kraken.com/0/public/Ticker?pair=XBTUSD",
+        "parser": lambda price_data: round(float(data["result"]["XXBTZUSD"]["c"][0]), 2)
+    },
+    {
+        "name": "OKX",
+        "url": "https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT",
+        "parser": lambda price_data: round(float(data["data"][0]["last"]), 2)
+    },
+    {
+        "name": "Bitstamp",
+        "url": "https://www.bitstamp.net/api/v2/ticker/btcusd/",
+        "parser": lambda price_data: round(float(data["last"]), 2)
+    },
+    {
+        "name": "Huobi",
+        "url": "https://api.huobi.pro/market/detail/merged?symbol=btcusdt",
+        "parser": lambda price_data: round(float(data["tick"]["close"]), 2)
+    },
+    {
+        "name": "ByBit",
+        "url": "https://api.bybit.com/v2/public/tickers?symbol=BTCUSD",
+        "parser": lambda price_data: round(float(data["result"][0]["last_price"]), 2)
+    },
+    {
+        "name": "MEXC",
+        "url": "https://api.mexc.com/api/v3/ticker/price?symbol=BTCUSDT",
+        "parser": lambda price_data: round(float(data["price"]), 2)
+    },
+]
 
 
 class BtcInfoThread(ManagedThread):
@@ -73,26 +110,8 @@ class BtcInfoThread(ManagedThread):
     @staticmethod
     def get_btc_price():
         """Fetch BTC price in USD from multiple free crypto APIs."""
-        API_SOURCES = [
-            {
-                "name": "Coingecko",
-                "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
-                "parser": lambda price_data: round(data["bitcoin"]["usd"], 2)
-            },
-            {
-                "name": "Kraken",
-                "url": "https://api.kraken.com/0/public/Ticker?pair=XBTUSD",
-                "parser": lambda price_data: round(float(data["result"]["XXBTZUSD"]["c"][0]), 2)
-            },
-            {
-                "name": "OKX",
-                "url": "https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT",
-                "parser": lambda price_data: round(float(data["data"][0]["last"]), 2)
-            }
-        ]
 
-        # Try one of the free crypto APIs to get the Bitcoin price
-        for source in API_SOURCES:
+        for source in BTC_PRICE_API_SOURCES:  # Try one of the free crypto APIs to get the Bitcoin price
             try:
                 response = requests.get(source["url"], timeout=10)
                 response.raise_for_status()


### PR DESCRIPTION
Hardened the `BTCInfo` thread to use more available free APIs to get the BTC Pricing info.   It also will handle not getting the BTC price from any of those APIs by zeroing out the BTC price.